### PR TITLE
Inherit from JupyterHandler instead of APIHandler

### DIFF
--- a/oss_pasarela/handlers.py
+++ b/oss_pasarela/handlers.py
@@ -9,7 +9,7 @@ import nbformat as nbf
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors import CellExecutionError
 
-from jupyter_server.base.handlers import APIHandler
+from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.utils import url_path_join
 import tornado
 
@@ -21,7 +21,9 @@ def _get_pasarela_usage():
     help_content = bytes_content.decode()
 
     return help_content
-class RouteHandler(APIHandler):
+
+
+class RouteHandler(JupyterHandler):
     @tornado.web.authenticated
     def get(self):
         code = self.get_argument("code", None)
@@ -93,7 +95,9 @@ class RouteHandler(APIHandler):
         full_url = self.request.full_url()
         match = re.search("(\/user\/)(.*)(\/pasarela)", full_url)
         self.redirect('http://' + self.request.host + '/user/' + match.group(2) + '/lab/tree/' + NOTEBOOK_NAME)
-class UsageHandler(APIHandler):
+
+
+class UsageHandler(JupyterHandler):
     @tornado.web.authenticated
     def get(self):
         # self.finish('This is a test')


### PR DESCRIPTION
these are not API endpoints, which should usually return JSON (and will return JSON for errors). For-humans (usually HTML) pages should inherit from JupyterHandler, instead.

One of the main differences between APIHandler and the base JupyterHandler is that APIHandler gives a 403 error on missing auth, while JupyterHandler will redirect to login to start the authentication flow.

This should fix the issue reported [on the forum](https://discourse.jupyter.org/t/problem-running-a-server-extension-using-user-redirect/20913)